### PR TITLE
Use fully-qualified name to refer to specific formula

### DIFF
--- a/Formula/game-porting-toolkit.rb
+++ b/Formula/game-porting-toolkit.rb
@@ -63,7 +63,7 @@ class GamePortingToolkit < Formula
   def install
     # Bypass the Homebrew shims to build native binaries with the dedicated compiler.
     # (PE binaries will be built with mingw32-gcc.)
-    compiler = Formula["game-porting-toolkit-compiler"]
+    compiler = Formula["apple/apple/game-porting-toolkit-compiler"]
     compiler_options = ["CC=#{compiler.bin}/clang",
                         "CXX=#{compiler.bin}/clang++"]
 


### PR DESCRIPTION
Trying to perform a clean install via terminal or GUI installer I was seeing the following error. After updating the path in the formula the installation is able to continue.

```
$ brew install apple/apple/game-porting-toolkit               
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Error: Formulae found in multiple taps:
       * apple/apple/game-porting-toolkit-compiler
       * gcenx/apple/game-porting-toolkit-compiler

Please use the fully-qualified name (e.g. apple/apple/game-porting-toolkit-compiler) to refer to a specific formula.
```